### PR TITLE
feat : 로그아웃 기능과 유저조회기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,9 +22,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'  // Web Starter
 	implementation 'org.projectlombok:lombok:1.18.24' // Lombok
 	implementation 'io.jsonwebtoken:jjwt:0.12.3'
-	implementation 'org.springframework.boot:spring-boot-starter-mail'//JavaMailSender
-
-
+	implementation 'org.springframework.boot:spring-boot-starter-mail'// JavaMailSender
 
 	runtimeOnly 'com.mysql:mysql-connector-j'  // MySQL Connector
 
@@ -32,11 +30,15 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok:1.18.24'
 	annotationProcessor 'org.projectlombok:lombok:1.18.24'
 
-	// Spring Boot Test 의존성 (JUnit 5 포함)
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'  // Test Starter (JUnit 5 포함)
+	// Spring Boot Test 의존성 (JUnit 5, Mockito 포함)
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
 
+
+	// Mockito 의존성
+	testImplementation 'org.mockito:mockito-core:5.8.1'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()  // JUnit Platform을 사용하도록 설정
+	useJUnitPlatform()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
 
 	// Mockito 의존성
-	testImplementation 'org.mockito:mockito-core:5.8.1'
+	testImplementation "org.mockito:mockito-core:5.11.0"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/myapp/Membership/controller/AuthController.java
+++ b/src/main/java/com/example/myapp/Membership/controller/AuthController.java
@@ -1,9 +1,6 @@
 package com.example.myapp.Membership.controller;
 
-import com.example.myapp.Membership.dto.LoginRequest;
-import com.example.myapp.Membership.dto.LoginResponse;
-import com.example.myapp.Membership.dto.RegisterRequest;
-import com.example.myapp.Membership.dto.RegisterResponse;
+import com.example.myapp.Membership.dto.*;
 import com.example.myapp.Membership.entity.User;
 import com.example.myapp.Membership.service.UserService;
 import org.springframework.http.HttpStatus;
@@ -71,36 +68,26 @@ public class AuthController {
 
     //아이디 찾기 엔드포인트
     @PostMapping("/find-id")
-    public ResponseEntity<?> findUserId(@RequestBody Map<String, String> request) {
-        String email = request.get("email");
-        if (email == null || email.isBlank()) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(Map.of("message", "이메일을 입력해주세요."));
-        }
-
-        User user = userService.findUserIdByEmail(email);
-        if(user == null) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(Map.of("message", "해당 이메일에 해당하는 아이디가 없습니다."));
-        }
-        return ResponseEntity.ok(Map.of("userId", user.getUserId()));
+    public ResponseEntity<FindIdResponse> findUserId(@RequestBody FindIdRequest request) {
+        FindIdResponse response = userService.findUserIdByEmail(request);
+        return ResponseEntity.ok(response);
     }
 
     //비밀번호 찾기 엔드포인트
     @PostMapping("/find-password")
-    public ResponseEntity<?> findPassword(@RequestBody Map<String, String> request){
-        String userId = request.get("userId");
-        String email = request.get("email");
-        
-        try{
-            userService.resetPasswordAndSendEmail(userId, email);
-            return ResponseEntity.ok(Map.of("success", true));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(Map.of("success", false, "message", e.getMessage()));
-        }
-        
+    public ResponseEntity<?> findPassword(@RequestBody FindPasswordRequest request) {
+        userService.resetPasswordAndSendEmail(request);
+        return ResponseEntity.ok(Map.of("success", true));
+    }
+
+    //로그아웃 엔드포인트
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout()
+    {
+        return ResponseEntity.ok(Map.of("message", "로그아웃됐습니다."));
+
     }
 
 
 }
+

--- a/src/main/java/com/example/myapp/Membership/controller/UserController.java
+++ b/src/main/java/com/example/myapp/Membership/controller/UserController.java
@@ -1,0 +1,26 @@
+package com.example.myapp.Membership.controller;
+
+import com.example.myapp.Membership.dto.UserInfoResponse;
+import com.example.myapp.Membership.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@CrossOrigin(origins = "*")
+@RequestMapping("/auth")
+public class UserController {
+
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    //유저정보조회 엔드포인트
+    @GetMapping("/{userId}")
+    public ResponseEntity<UserInfoResponse> getUserInfo(@PathVariable String userId) {
+        UserInfoResponse response = userService.getUserInfo(userId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/example/myapp/Membership/dto/FindIdRequest.java
+++ b/src/main/java/com/example/myapp/Membership/dto/FindIdRequest.java
@@ -1,6 +1,5 @@
 package com.example.myapp.Membership.dto;
 
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,9 +9,6 @@ import lombok.Setter;
 @NoArgsConstructor
 @Getter
 @Setter
-public class LoginRequest {
-    private String userId;
-    private String password;
-
-
+public class FindIdRequest {
+    private String email;
 }

--- a/src/main/java/com/example/myapp/Membership/dto/FindIdResponse.java
+++ b/src/main/java/com/example/myapp/Membership/dto/FindIdResponse.java
@@ -1,0 +1,12 @@
+package com.example.myapp.Membership.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FindIdResponse {
+    private String userId;
+
+
+}

--- a/src/main/java/com/example/myapp/Membership/dto/FindPasswordRequest.java
+++ b/src/main/java/com/example/myapp/Membership/dto/FindPasswordRequest.java
@@ -1,6 +1,5 @@
 package com.example.myapp.Membership.dto;
 
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,9 +9,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @Getter
 @Setter
-public class LoginRequest {
+public class FindPasswordRequest {
     private String userId;
-    private String password;
-
-
+    private String email;
 }

--- a/src/main/java/com/example/myapp/Membership/dto/FindPasswordResponse.java
+++ b/src/main/java/com/example/myapp/Membership/dto/FindPasswordResponse.java
@@ -1,0 +1,12 @@
+package com.example.myapp.Membership.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FindPasswordResponse {
+    private boolean success;
+    private String message;
+
+}

--- a/src/main/java/com/example/myapp/Membership/dto/UserInfoResponse.java
+++ b/src/main/java/com/example/myapp/Membership/dto/UserInfoResponse.java
@@ -1,0 +1,14 @@
+package com.example.myapp.Membership.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserInfoResponse {
+    private String nickname;
+    private String email;
+    private String tier;
+    private Integer teamId;
+
+}

--- a/src/main/java/com/example/myapp/Membership/entity/Team.java
+++ b/src/main/java/com/example/myapp/Membership/entity/Team.java
@@ -1,0 +1,44 @@
+package com.example.myapp.Membership.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Entity
+@Table(name = "team")
+@Getter
+@Setter
+@AllArgsConstructor
+public class Team {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer teamId;
+
+    @Column(nullable = false, unique = true)
+    private String teamName;
+
+    @Column(columnDefinition = "TEXT")
+    private String teamDescription;
+
+    @Column(nullable = false)
+    private int maxmember;
+
+    @Column(nullable = false)
+    private int currentMemberCount;
+
+    @Column(nullable = false)
+    private String teamTier;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "leader_id", nullable = false)
+    private User leader;
+
+
+    @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TeamMember> members;
+
+}

--- a/src/main/java/com/example/myapp/Membership/entity/TeamMember.java
+++ b/src/main/java/com/example/myapp/Membership/entity/TeamMember.java
@@ -1,0 +1,26 @@
+package com.example.myapp.Membership.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "teamMember")
+@Getter
+@Setter
+@AllArgsConstructor
+public class TeamMember {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer memberId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id", nullable = false)
+    private Team team;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+}

--- a/src/main/java/com/example/myapp/Membership/repository/TeamMemberRepository.java
+++ b/src/main/java/com/example/myapp/Membership/repository/TeamMemberRepository.java
@@ -1,0 +1,11 @@
+package com.example.myapp.Membership.repository;
+
+
+import com.example.myapp.Membership.entity.TeamMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface TeamMemberRepository extends JpaRepository<TeamMember, String> {
+    // 특정 유저 ID로 팀 멤버 정보 조회
+    Optional<TeamMember> findByUser_UserId(String userId);
+}

--- a/src/main/java/com/example/myapp/Membership/service/EmailService.java
+++ b/src/main/java/com/example/myapp/Membership/service/EmailService.java
@@ -15,7 +15,7 @@ public class EmailService {
         SimpleMailMessage message = new SimpleMailMessage();
         message.setTo(toEmail);
         message.setSubject("임시 비밀번호 안내");
-        message.setText("임시 비밀번호는: " + tempPassword + " 입니다.\n로그인 후 비밀번호를 변경해주세요.");
+        message.setText("임시 비밀번호는: " + tempPassword + " 입니다");
         mailSender.send(message);
     }
 }

--- a/src/main/java/com/example/myapp/Membership/service/SolvedAcService.java
+++ b/src/main/java/com/example/myapp/Membership/service/SolvedAcService.java
@@ -1,0 +1,33 @@
+package com.example.myapp.Membership.service;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Service
+public class SolvedAcService {
+
+    private final RestTemplate restTemplate;
+
+    public SolvedAcService(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    public int fetchTier(String userId) {
+        String url = "https://solved.ac/api/v3/user/show?handle=" + userId;
+
+        try {
+            ResponseEntity<Map> response = restTemplate.getForEntity(url, Map.class);
+            if (response.getStatusCode().is2xxSuccessful()) {
+                Map body = response.getBody();
+                return (int) body.get("tier");
+            } else {
+                throw new RuntimeException("Solved.ac API 호출 실패: " + response.getStatusCode());
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Solved.ac 호출 중 오류 발생", e);
+        }
+    }
+}

--- a/src/main/java/com/example/myapp/Membership/service/UserService.java
+++ b/src/main/java/com/example/myapp/Membership/service/UserService.java
@@ -44,7 +44,7 @@ public class UserService {
             throw new IllegalStateException("이미 존재하는 이메일입니다.");
         }
 
-        // SHA-256 해싱 적용
+        // SHA256 해싱 적용
         String hashedPassword = PasswordUtil.hashPassword(request.getPassword());
 
         int tier = solvedAcService.fetchTier(request.getUserId());

--- a/src/main/java/com/example/myapp/Membership/service/UserService.java
+++ b/src/main/java/com/example/myapp/Membership/service/UserService.java
@@ -7,6 +7,8 @@ import com.example.myapp.Membership.util.JwtTokenProvider;
 import com.example.myapp.Membership.entity.User;
 import com.example.myapp.Membership.repository.UserRepository;
 import com.example.myapp.Membership.util.PasswordUtil;
+import com.example.myapp.Membership.util.TierUtil;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -18,11 +20,17 @@ public class UserService {
     private final UserRepository userRepository;
     private final EmailService emailService;
     private final TeamMemberRepository teamMemberRepository;
+    private final SolvedAcService solvedAcService;
 
-    public UserService(UserRepository userRepository, EmailService emailService, TeamMemberRepository teamMemberRepository) {
+
+
+    public UserService(UserRepository userRepository, EmailService emailService, TeamMemberRepository teamMemberRepository,SolvedAcService solvedAcService ) {
         this.userRepository = userRepository;
         this.emailService = emailService;
         this.teamMemberRepository = teamMemberRepository;
+        this.solvedAcService = solvedAcService;
+
+
     }
 
 
@@ -39,12 +47,15 @@ public class UserService {
         // SHA-256 해싱 적용
         String hashedPassword = PasswordUtil.hashPassword(request.getPassword());
 
+        int tier = solvedAcService.fetchTier(request.getUserId());
+
+
         User user = new User(
                 request.getUserId(),
                 hashedPassword,
                 request.getNickname(),
                 request.getEmail(),
-                "UNRANKED"  // 기본 티어 설정
+                TierUtil.convertTier(tier)
         );
 
         return userRepository.save(user);
@@ -133,5 +144,6 @@ public class UserService {
         );
 
     }
+
 
 }

--- a/src/main/java/com/example/myapp/Membership/util/JwtTokenProvider.java
+++ b/src/main/java/com/example/myapp/Membership/util/JwtTokenProvider.java
@@ -7,7 +7,7 @@ import java.util.Date;
 
 public class JwtTokenProvider {
     public class SecretKey{
-        public static String JWT_SECRT_KEY = "helloworld"; //임의로 짠 키
+        public static String JWT_SECRT_KEY = "goormwebidproject_first"; //임의로 짠 키
     }
 
 

--- a/src/main/java/com/example/myapp/Membership/util/JwtTokenProvider.java
+++ b/src/main/java/com/example/myapp/Membership/util/JwtTokenProvider.java
@@ -7,21 +7,40 @@ import java.util.Date;
 
 public class JwtTokenProvider {
     public class SecretKey{
-        public static String JWT_SECRT_KEY = "goormwebidproject_first"; //임의로 짠 키
+        public static String JWT_SECRT_KEY = "goormwebidprojectfirst"; //임의로 짠 키
     }
 
-
+    
+    //토큰 생성
     public static String createToken(String userId, String tier){
         Date now = new Date();
         return Jwts.builder()
-                .setHeaderParam("type", "jwt") //Header값 ("alg", "typ")을 설정
+                .setHeaderParam("HS256", "JWT") //Header값 ("alg", "typ")을 설정
                 .claim("tier", tier) //쿠키에 저장되는 유저 데이터
                 .claim("id", userId) //쿠키에 저장되는 유저 데이터
-                .setSubject(userId) //tier 를 가진 유저의 인증 정보를 담고 있다는 토큰이라는 말
+                .setSubject(userId) //유저의 인증 정보를 담고 있다는 토큰이라는 말
                 .setIssuedAt(now) //토큰 생성 시간
-                .setExpiration(new Date(System.currentTimeMillis()+1*(1000*60*60*24*356))) //토큰 만료 시간
+                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60))  //토큰 만료 시간
                 .signWith(SignatureAlgorithm.HS256, SecretKey.JWT_SECRT_KEY)
                 .compact(); //토큰 생성
 
     }
+    
+    
+    //토큰 유효성 검사
+    public static boolean isTokenValid(String token) {
+        try {
+            Jwts.parser()
+                    .setSigningKey(SecretKey.JWT_SECRT_KEY)  // 서명 키로 서명 검증
+                    .build()
+                    .parseClaimsJws(token);  // 토큰을 파싱하면서 서명 검증
+
+            return true;
+        } catch (Exception e) {
+
+            return false;
+        }
+    }
+
+    
 }

--- a/src/main/java/com/example/myapp/Membership/util/TierUtil.java
+++ b/src/main/java/com/example/myapp/Membership/util/TierUtil.java
@@ -1,0 +1,22 @@
+package com.example.myapp.Membership.util;
+
+public class TierUtil {
+
+    private static final String[] TIER_NAMES = {
+            "UNRANKED", // 0
+            "BRONZE V", "BRONZE IV", "BRONZE III", "BRONZE II", "BRONZE I",         // 1~5
+            "SILVER V", "SILVER IV", "SILVER III", "SILVER II", "SILVER I",         // 6~10
+            "GOLD V", "GOLD IV", "GOLD III", "GOLD II", "GOLD I",                   // 11~15
+            "PLATINUM V", "PLATINUM IV", "PLATINUM III", "PLATINUM II", "PLATINUM I", // 16~20
+            "DIAMOND V", "DIAMOND IV", "DIAMOND III", "DIAMOND II", "DIAMOND I",    // 21~25
+            "RUBY V", "RUBY IV", "RUBY III", "RUBY II", "RUBY I",                    // 26~30
+            "MASTER" // 31
+    };
+
+    public static String convertTier(int tier) {
+        if (tier >= 0 && tier < TIER_NAMES.length) {
+            return TIER_NAMES[tier];
+        }
+        return "UNKNOWN";
+    }
+}

--- a/src/main/java/com/example/myapp/MyappApplication.java
+++ b/src/main/java/com/example/myapp/MyappApplication.java
@@ -1,0 +1,12 @@
+package com.example.myapp;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class MyappApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(MyappApplication.class, args);
+	}
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@
 spring.application.name=myapp
 
 # MySQL DB
-spring.datasource.url=jdbc:mysql://3.104.230.163:3306/mydatabase?serverTimezone=Asia/Seoul&useSSL=false&allowPublicKeyRetrieval=true
+spring.datasource.url=jdbc:mysql://3.104.230.163:3306/mydatabase
 spring.datasource.username=myuser
 spring.datasource.password=MySecurePW#2025
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
@@ -11,11 +11,11 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
-jwt.secret-key=helloworld
+jwt.secret-key=goormwebidproject_first
 logging.level.org.springframework=DEBUG
 
 
-#?? ???? ???? ???? ??
+
 # JavaMailSender ???? ? ??
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587

--- a/src/test/java/com/example/myapp/Membership/service/UserServiceTest.java
+++ b/src/test/java/com/example/myapp/Membership/service/UserServiceTest.java
@@ -1,0 +1,42 @@
+package com.example.myapp.Membership.service;
+
+import com.example.myapp.Membership.dto.RegisterRequest;
+import com.example.myapp.Membership.entity.User;
+import com.example.myapp.Membership.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private SolvedAcService solvedAcService;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    void registerUser_ShouldSucceed_WhenValidRequest() {
+        RegisterRequest request = new RegisterRequest("newUser", "email@test.com", "password", "닉네임");
+        User user = new User("newUser", "닉네임", "email@test.com", "password", "BRONZE");
+
+        when(solvedAcService.fetchTier("newUser")).thenReturn(5);
+        when(userRepository.save(any(User.class))).thenReturn(user);
+
+        User savedUser = userService.register(request);
+
+        assertNotNull(savedUser);
+        assertEquals("newUser", savedUser.getUserId());
+    }
+}


### PR DESCRIPTION
MemberShip
- controller
AuthController(인증에 관련된 엔드포인트 로직)
UserController(유저정보에 관련된 엔드포인트 로직)
- dto
CheckUserIdResponse(아이디 중복여부, 클라이언트한테 송신)
FindIdRequest(아이디 찾기, 클라이언트한테 수신)
FindIdResponse(아이디 찾기,클라이언트한테 송신)
FindPasswordRequest(비밀번호 찾기, 클라이언트한테 수신)
FindPasswordResponse(비밀번호 찾기, 클라이언트한테 송신)
LoginRequest(로그인, 클라이언트한테 수신)
LoginResponse(로그인, 클라이언트한테 송신)
RegisterRequest(회원가입, 클라이언트한테 수신)
RegisterResponse(회원가입, 클라이언트한테 송신)
UserInfoResponse(유저정보, 클라이언트한테 송신)
- entity
Team(MySQL에 있는 Team Table)
TeamMember(MySQL에 있는 TeamMember Table)
Uesr(MySQL에 있는 User Table)
- repository
TeamMemberRepository(인터페이스, SQL쿼리를 자동으로 만들어 주기때문에 사용, 특정 유저 ID로 팀 멤버 정보 조회)
UserRepository(인터페이스, SQL쿼리를 자동으로 만들어 주기때문에 사용, 이메일과 아이디 찾기, 이메일과 아이디가 존재하는지)
- service
EmailService(임시 비밀번호를 이메일로 보내는 로직)
SolvedAcService(solved.ac api를 이용해서 tier를 조회하는 로직)
UserService(회원가입, 로그인, 아이디/비밀번호 찾기, 아이디 중복로직, 유저정보조회 로직)
-util
extraInfoFromToken(토큰에서 로직과 티어를 추출하는 로직)
JwtTokenProvider(토큰을 생성하고 유효성 검사를 하는 로직)
PasswordUtil(패스워드를 해시값으로 치환해서 보안성을 높이는 로직)
TierUtil(숫자 형태의 티어 값을 문자열로 변환해줌)



